### PR TITLE
feat: 캐릭터 이동 + 대시 (#3)

### DIFF
--- a/scenes/levels/test_level.tscn
+++ b/scenes/levels/test_level.tscn
@@ -1,0 +1,37 @@
+[gd_scene load_steps=3 format=3 uid="uid://btestlevel001"]
+
+[ext_resource type="PackedScene" path="res://scenes/player/player.tscn" id="1_player"]
+
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_wall"]
+size = Vector2(1024.0, 16.0)
+
+[node name="TestLevel" type="Node2D"]
+
+[node name="Player" parent="." instance=ExtResource("1_player")]
+position = Vector2(512, 300)
+
+[node name="WallTop" type="StaticBody2D" parent="."]
+position = Vector2(512, 0)
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="WallTop"]
+shape = SubResource("RectangleShape2D_wall")
+
+[node name="WallBottom" type="StaticBody2D" parent="."]
+position = Vector2(512, 600)
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="WallBottom"]
+shape = SubResource("RectangleShape2D_wall")
+
+[node name="WallLeft" type="StaticBody2D" parent="."]
+position = Vector2(0, 300)
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="WallLeft"]
+shape = SubResource("RectangleShape2D_wall")
+rotation = 1.5708
+
+[node name="WallRight" type="StaticBody2D" parent="."]
+position = Vector2(1024, 300)
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="WallRight"]
+shape = SubResource("RectangleShape2D_wall")
+rotation = 1.5708

--- a/scenes/player/player.gd
+++ b/scenes/player/player.gd
@@ -1,0 +1,88 @@
+extends CharacterBody2D
+## 플레이어 이동 + 대시 로직
+
+# --- 이동 ---
+@export var speed: float = 200.0
+
+# --- 대시 ---
+@export var dash_speed: float = 1500.0
+@export var dash_duration: float = 0.1
+@export var dash_cooldown: float = 2.0
+@export var invincible_duration: float = 0.3
+
+# --- 내부 상태 ---
+var _last_direction: Vector2 = Vector2.RIGHT
+var _is_dashing: bool = false
+var _is_invincible: bool = false
+var _dash_timer: float = 0.0
+var _cooldown_timer: float = 0.0
+var _invincible_timer: float = 0.0
+
+@onready var _body_draw: Node2D = %BodyDraw
+
+
+func _physics_process(delta: float) -> void:
+	_update_timers(delta)
+
+	var input_direction: Vector2 = _get_input_direction()
+
+	if input_direction != Vector2.ZERO:
+		_last_direction = input_direction
+
+	if _is_dashing:
+		# 대시 중에는 입력 무시, 기존 velocity 유지
+		pass
+	else:
+		velocity = input_direction * speed
+		_try_dash()
+
+	move_and_slide()
+	_update_body_draw_rotation()
+
+
+func _get_input_direction() -> Vector2:
+	var direction: Vector2 = Input.get_vector("move_left", "move_right", "move_up", "move_down")
+	if direction.length() > 1.0:
+		direction = direction.normalized()
+	return direction
+
+
+func _try_dash() -> void:
+	if Input.is_action_just_pressed("dash") and is_dash_ready():
+		_is_dashing = true
+		_is_invincible = true
+		_dash_timer = dash_duration
+		_cooldown_timer = dash_cooldown
+		_invincible_timer = invincible_duration
+		velocity = _last_direction * dash_speed
+
+
+func _update_timers(delta: float) -> void:
+	if _dash_timer > 0.0:
+		_dash_timer -= delta
+		if _dash_timer <= 0.0:
+			_dash_timer = 0.0
+			_is_dashing = false
+
+	if _invincible_timer > 0.0:
+		_invincible_timer -= delta
+		if _invincible_timer <= 0.0:
+			_invincible_timer = 0.0
+			_is_invincible = false
+
+	if _cooldown_timer > 0.0:
+		_cooldown_timer -= delta
+		if _cooldown_timer <= 0.0:
+			_cooldown_timer = 0.0
+
+
+func _update_body_draw_rotation() -> void:
+	_body_draw.rotation = _last_direction.angle()
+
+
+func is_invincible() -> bool:
+	return _is_invincible
+
+
+func is_dash_ready() -> bool:
+	return _cooldown_timer <= 0.0 and not _is_dashing

--- a/scenes/player/player.tscn
+++ b/scenes/player/player.tscn
@@ -1,0 +1,32 @@
+[gd_scene load_steps=4 format=3 uid="uid://bplayer001"]
+
+[ext_resource type="Script" path="res://scenes/player/player.gd" id="1_player"]
+
+[sub_resource type="GDScript" id="GDScript_bodydraw"]
+script/source = "extends Node2D
+
+func _draw() -> void:
+	draw_circle(Vector2.ZERO, 16.0, Color.CORNFLOWER_BLUE)
+	var triangle: PackedVector2Array = PackedVector2Array([
+		Vector2(20.0, 0.0),
+		Vector2(10.0, -8.0),
+		Vector2(10.0, 8.0),
+	])
+	draw_colored_polygon(triangle, Color.WHITE)
+"
+
+[sub_resource type="CircleShape2D" id="CircleShape2D_col"]
+radius = 16.0
+
+[node name="Player" type="CharacterBody2D"]
+script = ExtResource("1_player")
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="."]
+shape = SubResource("CircleShape2D_col")
+
+[node name="BodyDraw" type="Node2D" parent="."]
+unique_name_in_owner = true
+script = SubResource("GDScript_bodydraw")
+
+[node name="Camera2D" type="Camera2D" parent="."]
+enabled = true

--- a/test/unit/test_player.gd
+++ b/test/unit/test_player.gd
@@ -1,0 +1,119 @@
+extends GutTest
+## Player 이동+대시 단위 테스트.
+## player.tscn을 instantiate해서 %BodyDraw @onready 참조를 보장한다.
+
+var _player: CharacterBody2D
+
+func before_each() -> void:
+	_player = preload("res://scenes/player/player.tscn").instantiate()
+	add_child(_player)
+
+func after_each() -> void:
+	_player.queue_free()
+
+
+# --- 초기 상태 ---
+
+func test_initial_velocity_is_zero() -> void:
+	assert_eq(_player.velocity, Vector2.ZERO, "초기 velocity는 Vector2.ZERO")
+
+func test_initial_not_dashing() -> void:
+	assert_false(_player._is_dashing, "초기 대시 상태는 false")
+
+func test_initial_not_invincible() -> void:
+	assert_false(_player._is_invincible, "초기 무적 상태는 false")
+
+func test_initial_dash_ready() -> void:
+	assert_true(_player.is_dash_ready(), "초기에는 대시 준비 완료")
+
+func test_last_direction_initial_value() -> void:
+	assert_eq(_player._last_direction, Vector2.RIGHT, "초기 마지막 방향은 Vector2.RIGHT")
+
+
+# --- export 기본값 ---
+
+func test_default_speed_200() -> void:
+	assert_eq(_player.speed, 200.0, "기본 이동 속도는 200.0")
+
+func test_default_dash_speed_1500() -> void:
+	assert_eq(_player.dash_speed, 1500.0, "기본 대시 속도는 1500.0")
+
+
+# --- 대시 발동 (내부 상태 직접 설정) ---
+
+func test_dash_sets_dashing_and_invincible() -> void:
+	_player._is_dashing = true
+	_player._is_invincible = true
+	_player._dash_timer = _player.dash_duration
+	_player._cooldown_timer = _player.dash_cooldown
+	_player._invincible_timer = _player.invincible_duration
+	_player.velocity = _player._last_direction * _player.dash_speed
+
+	assert_true(_player._is_dashing, "대시 중 _is_dashing은 true")
+	assert_true(_player._is_invincible, "대시 중 _is_invincible은 true")
+	assert_eq(
+		_player.velocity,
+		Vector2.RIGHT * _player.dash_speed,
+		"대시 velocity는 last_direction * dash_speed"
+	)
+
+func test_dash_sets_cooldown() -> void:
+	_player._cooldown_timer = _player.dash_cooldown
+
+	assert_gt(_player._cooldown_timer, 0.0, "대시 후 쿨다운 타이머가 양수")
+
+func test_dash_not_ready_during_cooldown() -> void:
+	_player._cooldown_timer = _player.dash_cooldown
+
+	assert_false(_player.is_dash_ready(), "쿨다운 중에는 대시 불가")
+
+
+# --- 타이머 로직 (_update_timers 직접 호출) ---
+
+func test_dash_ends_after_duration() -> void:
+	_player._is_dashing = true
+	_player._dash_timer = _player.dash_duration
+
+	# dash_duration보다 큰 delta를 넘겨서 타이머 만료
+	_player._update_timers(_player.dash_duration + 0.01)
+
+	assert_false(_player._is_dashing, "dash_duration 경과 후 _is_dashing은 false")
+	assert_eq(_player._dash_timer, 0.0, "만료된 dash_timer는 0.0")
+
+func test_invincible_ends_after_duration() -> void:
+	_player._is_invincible = true
+	_player._invincible_timer = _player.invincible_duration
+
+	_player._update_timers(_player.invincible_duration + 0.01)
+
+	assert_false(_player._is_invincible, "invincible_duration 경과 후 _is_invincible은 false")
+	assert_eq(_player._invincible_timer, 0.0, "만료된 invincible_timer는 0.0")
+
+func test_cooldown_decreases_over_time() -> void:
+	_player._cooldown_timer = _player.dash_cooldown
+
+	var delta: float = 0.5
+	_player._update_timers(delta)
+
+	assert_almost_eq(
+		_player._cooldown_timer,
+		_player.dash_cooldown - delta,
+		0.001,
+		"쿨다운 타이머는 delta만큼 감소"
+	)
+
+
+# --- is_invincible / is_dash_ready 공개 메서드 ---
+
+func test_is_invincible_returns_state() -> void:
+	_player._is_invincible = true
+	assert_true(_player.is_invincible(), "is_invincible()은 _is_invincible 반환")
+
+	_player._is_invincible = false
+	assert_false(_player.is_invincible(), "is_invincible()은 _is_invincible 반환")
+
+func test_is_dash_ready_false_while_dashing() -> void:
+	_player._is_dashing = true
+	_player._cooldown_timer = 0.0
+
+	assert_false(_player.is_dash_ready(), "대시 중에는 is_dash_ready()가 false")


### PR DESCRIPTION
## 요약
- CharacterBody2D 기반 WASD 8방향 이동 (200px/s) + Space 대시 (쿨다운 2s, 무적 0.3s)
- 도형 렌더링 (파란 원 + 방향 삼각형) + Camera2D 팔로우
- GUT 단위 테스트 15개 (전체 46개 PASS)

## 변경 사항
- `scenes/player/player.gd` — 이동+대시 로직 (velocity 기반 move_and_slide)
- `scenes/player/player.tscn` — Player 씬 (CollisionShape2D, BodyDraw 인라인, Camera2D)
- `scenes/levels/test_level.tscn` — 수동 테스트용 레벨 (4면 벽)
- `test/unit/test_player.gd` — 초기 상태, 타이머, 대시 상태 검증

## 미해결 사항
- 테스트 커버리지 경계선(6/10): `_try_dash()` 통합 테스트(InputSender) 추후 추가 권고
- 대시 종료 시 급정지 UX: 감속 구간 추후 검토
- 무적 시각 피드백(점멸 등) 미구현: 차후 이슈로 분리 가능

Closes #3

---
<sub>워크플로우 로그는 이슈 코멘트 참조</sub>